### PR TITLE
Verbatim-Safe Boxes and Environments

### DIFF
--- a/beamerthemeuulm.sty
+++ b/beamerthemeuulm.sty
@@ -340,12 +340,19 @@
     uulm@tightboxstyle/.style n args=3{uulm@basic-boxstyle={#1}{#2}{#3}{0mm},colback=white}
 }
 
+% we could group this by a generation macro
 \renewtcolorbox{definition}[2][]{uulm@boxstyle={#1}{#2}{orange}}
+\newtcbox\mydefinition[2][]{uulm@boxstyle={#1}{#2}{orange}}
 \newtcolorbox{definitiontight}[2][]{uulm@tightboxstyle={#1}{#2}{orange}}
+\newtcbox\mydefinitiontight[2][]{uulm@tightboxstyle={#1}{#2}{orange}}
 
 \renewtcolorbox{example}[2][]{uulm@boxstyle={#1}{#2}{blue}}
+\newtcbox\myexample[2][]{uulm@boxstyle={#1}{#2}{blue}}
 \newtcolorbox{exampletight}[2][]{uulm@tightboxstyle={#1}{#2}{blue}}
+\newtcbox\myexampletight[2][]{uulm@tightboxstyle={#1}{#2}{blue}}
 
 \renewtcolorbox{note}[2][]{uulm@boxstyle={#1}{#2}{red}}
+\newtcbox\mynote[2][]{uulm@boxstyle={#1}{#2}{red}}
 \newtcolorbox{notetight}[2][]{uulm@tightboxstyle={#1}{#2}{red}}
+\newtcbox\mynotetight[2][]{uulm@tightboxstyle={#1}{#2}{red}}
 % ---------------------------------------------

--- a/beamerthemeuulm.sty
+++ b/beamerthemeuulm.sty
@@ -254,8 +254,10 @@
 % protective groups and the plain definition. Assuming, that no non-export user will
 % use plain macro definitions, we will use currenvir guards.
 
+\newcount\uulm@splitter@nextcount
+
 % macro name [and text] | number of old args | old definition
-% | new definition (next-target only,no args => next)
+% | new definition (next-target only,no args => first[|second|third|... optional if not needed])
 \def\uulm@CreateSplitterBox#1#2#3#4{%
 % with this we define a new macro which maps to the text-name of the environment
 % therefore, '\uulm@CreateSplitterBox{abcd}...' would produce:
@@ -294,13 +296,18 @@
 % latex will insert spaces at each newline (e.g. <X>, same for the passed #2)
 % and we do not want them!!
 % in short, the following to lines define the macros used when in environment-mode
-\@namedef{uulm@#1}{\columns[c,onlytextwidth]\def\next{#4}\next}
-\@namedef{end#1}{\endcolumns}
+% with \uulm@splitter@nextcount we count the number of times, next has been called
+\@namedef{uulm@#1}{\begingroup\let\all\@uulm@set@all#4\columns[c,onlytextwidth]\first}
+\@namedef{end#1}{\endcolumns\endgroup}
 }
+
+% just a shortcut to set all columns the same way, useful, whenever there are no animations
+% will be accessible as '\all' whenever useful
+\def\@uulm@set@all#1{\def\first{\column#1}\def\second{\column#1}\def\third{\column#1}}
 
 % corresponds to '\halfpage', however, with the new columns we could use larger values
 % (same for thirdnext)
-\def\halfnext{{.48\textwidth}}
+\def\halfnext{{.489\textwidth}}
 % corresponds to '\thirdpage'
 \def\thirdnext{{.31\textwidth}}
 
@@ -311,83 +318,72 @@
 % this enables us to refer to them with '#1' and '#2 in the next argument which basically
 % just holds the definition of the original '\leftandright'-macro
 % i removed some newlines to make it more compact (but they do not matter)
-% the last macro defines the new definition of '\next' which acts as the splitter
-\uulm@CreateSplitterBox{leftandright}{2}{\halfpage{#1}\hfill\halfpage{#2}}{\column\halfnext}
+% the last macro defines the new definition of the column splitters first|second...
+\uulm@CreateSplitterBox{leftandright}{2}{\halfpage{#1}\hfill\halfpage{#2}}{\all\halfnext}
 
-\uulm@CreateSplitterBox{leftmiddleandright}{3}{\thirdpage{#1}\hfill\thirdpage{#2}\hfill\thirdpage{#3}}{\column\thirdnext}
+\uulm@CreateSplitterBox{leftmiddleandright}{3}{\thirdpage{#1}\hfill\thirdpage{#2}\hfill\thirdpage{#3}}{\all\thirdnext}
 
+\uulm@CreateSplitterBox{leftthenright}{2}{\halfpage{#1}\hfill\onslide<2->{\halfpage{#2}}}{\def\first{\column\halfnext}\def\second{\column<2->\halfnext}}
 
-\newcommand{\leftthenright}[2]{
-    \halfpage{#1}
-    \hfill
-    \onslide<2->{\halfpage{#2}}
-}
+\uulm@CreateSplitterBox{rightthenleft}{2}{\onslide<2->{\halfpage{#1}}\hfill\halfpage{#2}}{\def\first{\column<2->\halfnext}\def\second{\column\halfnext}}
 
-\newcommand{\rightthenleft}[2]{
-    \onslide<2->{\halfpage{#1}}
-    \hfill
-    \halfpage{#2}
-}
+\uulm@CreateSplitterBox{leftmiddlethenright}{3}{\thirdpage{#1}\hfill\onslide<2->{\thirdpage{#2}}\hfill\onslide<3->{\thirdpage{#2}}}{\def\first{\column\thirdnext}\def\second{\column<2->\thirdnext}\def\third{\column<3->\thirdnext}}
 
-\newcommand{\leftmiddlethenright}[3]{
-	\thirdpage{#1}
-    \hfill
-    \onslide<2->{\thirdpage{#2}}
-    \hfill
-    \onslide<3->{\thirdpage{#3}}
-}
+\uulm@CreateSplitterBox{rightmiddlethenleft}{3}{\onslide<3->{\thirdpage{#1}}\hfill\onslide<2->{\thirdpage{#2}}\hfill\thirdpage{#2}}{\def\first{\column<3->\thirdnext}\def\second{\column<2->\thirdnext}\def\third{\column\thirdnext}}
 
-\newcommand{\rightmiddlethenleft}[3]{
-	\onslide<3->{\thirdpage{#1}}
-    \hfill
-    \onslide<2->{\thirdpage{#2}}
-    \hfill
-    \thirdpage{#3}
-}
+% for the or environments we simply change the first-second-third definitions
+\uulm@CreateSplitterBox{leftorright}{2}{\ifrecording
+\onslide<1>{\halfpage{#1}}
+\onslide<2>{\hfill}
+\onslide<3>{\halfpage{#2}}
+\else
+\leftthenright{#1}{#2}
+\fi}{\ifrecording
+\def\first{\column<1>\halfnext}\def\second{\column<3>\halfnext}%
+\else
+\def\first{\column\halfnext}\def\second{\column<2->\halfnext}%
+\fi}
 
-\newcommand{\leftorright}[2]{ % only works in recording mode
-    \ifrecording
-    \onslide<1>{\halfpage{#1}}
-    \onslide<2>{\hfill}
-    \onslide<3>{\halfpage{#2}}
-    \else
-	\leftthenright{#1}{#2}
-	\fi
-}
+\uulm@CreateSplitterBox{rightorleft}{2}{\ifrecording
+\onslide<3>{\halfpage{#1}}
+\onslide<2>{\hfill}
+\onslide<1>{\halfpage{#2}}
+\else
+\leftthenright{#1}{#2}
+\fi}{\ifrecording
+\def\first{\column<3>\halfnext}\def\second{\column<1>\halfnext}%
+\else
+\def\first{\column<2->\halfnext}\def\second{\column\halfnext}%
+\fi}
 
-\newcommand{\rightorleft}[2]{ % only works in recording mode
-    \ifrecording
-    \onslide<3>{\halfpage{#1}}
-    \onslide<2>{\hfill}
-    \onslide<1>{\halfpage{#2}}
-    \else
-	\rightthenleft{#1}{#2}
-	\fi
-}
+\uulm@CreateSplitterBox{leftmiddleorright}{3}{\ifrecording
+\onslide<1>{\thirdpage{#1}}
+\onslide<2>{\hfill}
+\onslide<3>{\thirdpage{#2}}
+\onslide<4>{\hfill}
+\onslide<5>{\thirdpage{#3}}
+\else
+\leftmiddlethenright{#1}{#2}
+\fi}{\ifrecording
+\def\first{\column\thirdnext}\def\second{\column<3>\thirdnext}\def\third{\column<5>\thirdnext}%
+\else
+\def\first{\column\thirdnext}\def\second{\column<2->\thirdnext}\def\third{\column<3->\thirdnext}%
+\fi}
 
-\newcommand{\leftmiddleorright}[3]{ % only works in recording mode
-    \ifrecording
-    \onslide<1>{\thirdpage{#1}}
-    \onslide<2>{\hfill}
-    \onslide<3>{\thirdpage{#2}}
-    \onslide<4>{\hfill}
-    \onslide<5>{\thirdpage{#3}}
-    \else
-	\leftmiddlethenright{#1}{#2}{#3}
-	\fi
-}
+\uulm@CreateSplitterBox{rightmiddleorleft}{3}{\ifrecording
+\onslide<5>{\thirdpage{#1}}
+\onslide<4>{\hfill}
+\onslide<3>{\thirdpage{#2}}
+\onslide<2>{\hfill}
+\onslide<1>{\thirdpage{#3}}
+\else
+\rightmiddlethenleft{#1}{#2}
+\fi}{\ifrecording
+\def\first{\column<4->\thirdnext}\def\second{\column<3>\thirdnext}\def\third{\column\thirdnext}%
+\else
+\def\first{\column<3->\thirdnext}\def\second{\column<2->\thirdnext}\def\third{\column\thirdnext}%
+\fi}
 
-\newcommand{\rightmiddleorleft}[3]{ % only works in recording mode
-    \ifrecording
-    \onslide<5>{\thirdpage{#1}}
-    \onslide<4>{\hfill}
-    \onslide<3>{\thirdpage{#2}}
-    \onslide<2>{\hfill}
-    \onslide<1>{\thirdpage{#3}}
-    \else
-	\rightmiddlethenleft{#1}{#2}{#3}
-	\fi
-}
 % ---------------------------------------------
 
 

--- a/beamerthemeuulm.sty
+++ b/beamerthemeuulm.sty
@@ -342,17 +342,17 @@
 
 % we could group this by a generation macro
 \renewtcolorbox{definition}[2][]{uulm@boxstyle={#1}{#2}{orange}}
-\newtcbox\mydefinition[2][]{uulm@boxstyle={#1}{#2}{orange}}
+\newtcbox\mydefinition[2][]{capture=minipage,uulm@boxstyle={#1}{#2}{orange}}
 \newtcolorbox{definitiontight}[2][]{uulm@tightboxstyle={#1}{#2}{orange}}
-\newtcbox\mydefinitiontight[2][]{uulm@tightboxstyle={#1}{#2}{orange}}
+\newtcbox\mydefinitiontight[2][]{capture=minipage,uulm@tightboxstyle={#1}{#2}{orange}}
 
 \renewtcolorbox{example}[2][]{uulm@boxstyle={#1}{#2}{blue}}
-\newtcbox\myexample[2][]{uulm@boxstyle={#1}{#2}{blue}}
+\newtcbox\myexample[2][]{capture=minipage,uulm@boxstyle={#1}{#2}{blue}}
 \newtcolorbox{exampletight}[2][]{uulm@tightboxstyle={#1}{#2}{blue}}
-\newtcbox\myexampletight[2][]{uulm@tightboxstyle={#1}{#2}{blue}}
+\newtcbox\myexampletight[2][]{capture=minipage,uulm@tightboxstyle={#1}{#2}{blue}}
 
 \renewtcolorbox{note}[2][]{uulm@boxstyle={#1}{#2}{red}}
-\newtcbox\mynote[2][]{uulm@boxstyle={#1}{#2}{red}}
+\newtcbox\mynote[2][]{capture=minipage,uulm@boxstyle={#1}{#2}{red}}
 \newtcolorbox{notetight}[2][]{uulm@tightboxstyle={#1}{#2}{red}}
-\newtcbox\mynotetight[2][]{uulm@tightboxstyle={#1}{#2}{red}}
+\newtcbox\mynotetight[2][]{capture=minipage,uulm@tightboxstyle={#1}{#2}{red}}
 % ---------------------------------------------

--- a/beamerthemeuulm.sty
+++ b/beamerthemeuulm.sty
@@ -342,8 +342,20 @@
 
 % name | color
 \def\uulm@MakeNewBox#1#2{
+% renew will not work if we define a box that does not already exist in beamer
+% we could check this by \ifcsname #1\endcsname...\else...\fi
+% however, for the moment this is not necessary
+% in the definition #1 and #2 refer to the arguments of \uulm@MakeNewBox
+% while ##1 and ##2 to refer to the arguments passed on to the new tcolorbox.
+% therefore, with '\uulm@MakeNewBox{definition}{orange}', we create a new tcolorbox
+% named 'definition' which wenn called with '\begin{definition}[top=10mm]{My title}...'
+% will result in the option list 'uulm@boxstyle={top=10mm}{My title}{orange}'
 \renewtcolorbox{#1}[2][]{uulm@boxstyle={##1}{##2}{#2}}
+% here, we re-create the old macros (e.g. '\mydefinition')
+% 'capture=minipage' ensures their behavior is similar to the previous one (the default for
+% tcbox would be hbox and no longer fill the width)
 \expandafter\newtcbox\csname my#1\endcsname[2][]{capture=minipage,uulm@boxstyle={##1}{##2}{#2}}
+% now, we do the same for the tight-version of the boxes
 \newtcolorbox{#1tight}[2][]{uulm@tightboxstyle={##1}{##2}{#2}}
 \expandafter\newtcbox\csname my#1tight\endcsname[2][]{capture=minipage,uulm@tightboxstyle={##1}{##2}{#2}}
 }

--- a/beamerthemeuulm.sty
+++ b/beamerthemeuulm.sty
@@ -255,13 +255,7 @@
     \halfpage{#2}
 }
 
-\newcommand{\leftmiddleandright}[3]{
-	\thirdpage{#1}
-    \hfill
-    \thirdpage{#2}
-    \hfill
-    \thirdpage{#3}
-}
+\newenvironment{leftmiddleandright}{\columns[c,onlytextwidth]\def\next{\column{.31\textwidth}}\next}{\endcolumns}
 
 \newcommand{\leftthenright}[2]{
     \halfpage{#1}
@@ -340,11 +334,7 @@
 % ---------------------------------------------
 % color boxes
 % ---------------------------------------------
-\newcommand{\mydefinition}[2]{
-	\begin{tcolorbox}[title={\setlength{\parskip}{0ex}\vphantom{/}#1},colback=orange!10,colframe=orange!30,coltitle=black,fonttitle=\bfseries,left=1mm,right=1mm,top=1mm,bottom=1mm]
-		#2
-	\end{tcolorbox}
-}
+\renewtcolorbox{definition}[2][]{title={\setlength{\parskip}{0ex}\vphantom{/}#2},colback=orange!10,colframe=orange!30,coltitle=black,fonttitle=\bfseries,left=1mm,right=1mm,top=1mm,bottom=1mm,#1}
 
 \newcommand{\mydefinitiontight}[2]{
 	\begin{tcolorbox}[title={\setlength{\parskip}{0ex}\vphantom{/}#1},colback=white,colframe=orange!30,coltitle=black,fonttitle=\bfseries,left=0mm,right=0mm,top=0mm,bottom=0mm]

--- a/beamerthemeuulm.sty
+++ b/beamerthemeuulm.sty
@@ -248,33 +248,40 @@
 	\end{minipage}
 }
 
-% macro name [and text] | number of old args | old definition
-% | new definition (next-target only,no args => next)
-\long\def\uulm@CreateSplitterBox#1#2#3#4{%
-\@namedef{uulm@txt@#1}{#1}
-\edef\@tmp{\noexpand\@namedef{#1}{%
-\noexpand\ifx\expandonce{\csname uulm@txt@#1\endcsname}\noexpand\@currenvir\noexpand\expandafter\expandonce{\csname uulm@#1\endcsname}\noexpand\else\noexpand\expandafter\expandonce{\csname uulm@old@#1\endcsname}\noexpand\fi}}
-\@tmp
-\expandafter\newcommand\csname uulm@old@#1\endcsname[#2]{#3}
-\@namedef{uulm@#1}{\columns[c,onlytextwidth]\def\next{#4}\next}
-\@namedef{end#1}{\endcolumns}
-}
-\uulm@CreateSplitterBox{leftandright}{2}{\halfpage{#1}\hfill\halfpage{#2}}{\column{.48\textwidth}}
-
 % the old version allowed to pass on three macros, we want to support this non-verbatim-safe
 % variant for legacy reasons. With '\@ifnextchar\bgroup' we could check if this macro
 % is followed by an open brace. This is fragile, because we do no longer separate between
 % protective groups and the plain definition. Assuming, that no non-export user will
 % use plain macro definitions, we will use currenvir guards.
-\def\uulm@txt@leftmiddleandright{leftmiddleandright}%
-\def\leftmiddleandright{\ifx\@currenvir\uulm@txt@leftmiddleandright\expandafter\uulm@leftmiddleright\else\expandafter\uulm@old@leftmiddleright\fi}
-\def\uulm@old@leftmiddleright#1#2#3{%
-	\thirdpage{#1}%
-    \hfill
-    \thirdpage{#2}%
-    \hfill
-    \thirdpage{#3}%
-}
+
+% macro name [and text] | number of old args | old definition
+% | new definition (next-target only,no args => next)
+\def\uulm@CreateSplitterBox#1#2#3#4{%
+% with this we define a new macro which maps to the text-name of the environment
+% therefore, '\uulm@CreateSplitterBox{abcd}...' would produce:
+% \def\uulm@txt@abcd{abcd}
+\@namedef{uulm@txt@#1}{#1}
+% why the edef hell? well it 1) ensures that the expansions are correct and
+% 2) makes the resulting macro faster :D
+% let's reconsider '\uulm@CreateSplitterBox{abcd}...', the execution of '\@tmp'
+% will execute:
+% \def\abcd{\ifx\uulm@txt@abcd\@currenvir\expandafter\uulm@abcd\else\expandafter\uulm@old@abcd\fi}
+% because this is far more readable, i will explain the contents with this sample definition:
+% '\ifx\uulm@txt@abcd\@currenvir' will check, if the textual representation of the environment
+% '\uulm@txt@abcd => abcd' expands similar to '\@currenvir' which is the macro handled by LaTeX
+% when using '\begin{abcd}'. Therefore we detect (based on our assumption) if we have been called
+% as '\begin{abcd}...\next...\end{abcd}' (true) or as '\abcd{...}{...}...' (false)
+% depending on that, we will use either '\uulm@abcd' or '\uulm@old@abcd'
+% the '\expandafter' before them, defers their expansion after the '\ifx' is completed.
+\edef\@tmp{\noexpand\@namedef{#1}{%
+\noexpand\ifx\expandonce{\csname uulm@txt@#1\endcsname}\noexpand\@currenvir\noexpand\expandafter\expandonce{\csname uulm@#1\endcsname}\noexpand\else\noexpand\expandafter\expandonce{\csname uulm@old@#1\endcsname}\noexpand\fi}}
+% this will execute the edef-ed '\@tmp' (*e*def because it will fully expand its definition)
+% the '\noexpand' and '\expandonce' (etoolbox) in the definition will stop the expansion.
+\@tmp
+% now, '\abcd' is defined
+% with this we define the old macro definition, see the creation of 'leftandright'
+% below for a clearer explanation
+\expandafter\newcommand\csname uulm@old@#1\endcsname[#2]{#3}
 % TODO: to be honest, it would be better to patch the old variants so they work similar to
 % 'onlytextwidth', but the old version of `leftmiddleright` did not implement this behavior,
 % and therefore, fails with the internal padding of minipages and spacing problems:
@@ -286,6 +293,22 @@
 % \end{minipage}<X>
 % latex will insert spaces at each newline (e.g. <X>, same for the passed #2)
 % and we do not want them!!
+% in short, the following to lines define the macros used when in environment-mode
+\@namedef{uulm@#1}{\columns[c,onlytextwidth]\def\next{#4}\next}
+\@namedef{end#1}{\endcolumns}
+}
+\uulm@CreateSplitterBox{leftandright}{2}{\halfpage{#1}\hfill\halfpage{#2}}{\column{.48\textwidth}}
+
+\def\uulm@txt@leftmiddleandright{leftmiddleandright}%
+\def\leftmiddleandright{\ifx\@currenvir\uulm@txt@leftmiddleandright\expandafter\uulm@leftmiddleright\else\expandafter\uulm@old@leftmiddleright\fi}
+\def\uulm@old@leftmiddleright#1#2#3{%
+	\thirdpage{#1}%
+    \hfill
+    \thirdpage{#2}%
+    \hfill
+    \thirdpage{#3}%
+}
+
 \def\uulm@leftmiddleright{\columns[c,onlytextwidth]\def\next{\column{.31\textwidth}}\next}
 \def\endleftmiddleandright{\endcolumns}
 

--- a/beamerthemeuulm.sty
+++ b/beamerthemeuulm.sty
@@ -255,7 +255,33 @@
     \halfpage{#2}
 }
 
-\newenvironment{leftmiddleandright}{\columns[c,onlytextwidth]\def\next{\column{.31\textwidth}}\next}{\endcolumns}
+% the old version allowed to pass on three macros, we want to support this non-verbatim-safe
+% variant for legacy reasons. With '\@ifnextchar\bgroup' we could check if this macro
+% is followed by an open brace. This is fragile, because we do no longer separate between
+% protective groups and the plain definition. Assuming, that no non-export user will
+% use plain macro definitions, we will use currenvir guards.
+\def\uulm@txt@leftmiddleandright{leftmiddleandright}%
+\def\leftmiddleandright{\ifx\@currenvir\uulm@txt@leftmiddleandright\expandafter\uulm@leftmiddleright\else\expandafter\uulm@old@leftmiddleright\fi}
+\def\uulm@old@leftmiddleright#1#2#3{%
+	\thirdpage{#1}%
+    \hfill
+    \thirdpage{#2}%
+    \hfill
+    \thirdpage{#3}%
+}
+% TODO: to be honest, it would be better to patch the old variants so they work similar to
+% 'onlytextwidth', but the old version of `leftmiddleright` did not implement this behavior,
+% and therefore, fails with the internal padding of minipages and spacing problems:
+%    \partofpage{<X>
+% \begin{minipage}{0.#1\textwidth}
+%     \begin{flushleft}
+%         #2
+%     \end{flushleft}
+% \end{minipage}<X>
+% latex will insert spaces at each newline (e.g. <X>, same for the passed #2)
+% and we do not want them!!
+\def\uulm@leftmiddleright{\columns[c,onlytextwidth]\def\next{\column{.31\textwidth}}\next}
+\def\endleftmiddleandright{\endcolumns}
 
 \newcommand{\leftthenright}[2]{
     \halfpage{#1}

--- a/beamerthemeuulm.sty
+++ b/beamerthemeuulm.sty
@@ -259,12 +259,7 @@
 \@namedef{uulm@#1}{\columns[c,onlytextwidth]\def\next{#4}\next}
 \@namedef{end#1}{\endcolumns}
 }
-\errorcontextlines9999
-\uulm@CreateSplitterBox{leftandright}{2}{
-    \halfpage{#1}
-    \hfill
-    \halfpage{#2}
-}{\column{.48\textwidth}}
+\uulm@CreateSplitterBox{leftandright}{2}{\halfpage{#1}\hfill\halfpage{#2}}{\column{.48\textwidth}}
 
 % the old version allowed to pass on three macros, we want to support this non-verbatim-safe
 % variant for legacy reasons. With '\@ifnextchar\bgroup' we could check if this macro

--- a/beamerthemeuulm.sty
+++ b/beamerthemeuulm.sty
@@ -341,29 +341,11 @@
 }
 
 \renewtcolorbox{definition}[2][]{uulm@boxstyle={#1}{#2}{orange}}
-\newtcolorbox{mydefinitiontight}[2][]{uulm@tightboxstyle={#1}{#2}{orange}}
+\newtcolorbox{definitiontight}[2][]{uulm@tightboxstyle={#1}{#2}{orange}}
 
-\newcommand{\myexample}[2]{
-	\begin{tcolorbox}[title={\setlength{\parskip}{0ex}\vphantom{/}#1},colback=blue!10,colframe=blue!30,coltitle=black,fonttitle=\bfseries,left=1mm,right=1mm,top=1mm,bottom=1mm]
-		#2
-	\end{tcolorbox}
-}
+\renewtcolorbox{example}[2][]{uulm@boxstyle={#1}{#2}{blue}}
+\newtcolorbox{exampletight}[2][]{uulm@tightboxstyle={#1}{#2}{blue}}
 
-\newcommand{\myexampletight}[2]{
-	\begin{tcolorbox}[title={\setlength{\parskip}{0ex}\vphantom{/}#1},colback=white,colframe=blue!30,coltitle=black,fonttitle=\bfseries,left=0mm,right=0mm,top=0mm,bottom=0mm]
-		#2
-	\end{tcolorbox}
-}
-
-\newcommand{\mynote}[2]{
-	\begin{tcolorbox}[title={\setlength{\parskip}{0ex}\vphantom{/}#1},colback=red!10,colframe=red!30,coltitle=black,fonttitle=\bfseries,left=1mm,right=1mm,top=1mm,bottom=1mm]
-		#2
-	\end{tcolorbox}
-}
-
-\newcommand{\mynotetight}[2]{
-	\begin{tcolorbox}[title={\setlength{\parskip}{0ex}\vphantom{/}#1},colback=white,colframe=red!30,coltitle=black,fonttitle=\bfseries,left=0mm,right=0mm,top=0mm,bottom=0mm]
-		#2
-	\end{tcolorbox}
-}
+\renewtcolorbox{note}[2][]{uulm@boxstyle={#1}{#2}{red}}
+\newtcolorbox{notetight}[2][]{uulm@tightboxstyle={#1}{#2}{red}}
 % ---------------------------------------------

--- a/beamerthemeuulm.sty
+++ b/beamerthemeuulm.sty
@@ -297,20 +297,25 @@
 \@namedef{uulm@#1}{\columns[c,onlytextwidth]\def\next{#4}\next}
 \@namedef{end#1}{\endcolumns}
 }
-\uulm@CreateSplitterBox{leftandright}{2}{\halfpage{#1}\hfill\halfpage{#2}}{\column{.48\textwidth}}
 
-\def\uulm@txt@leftmiddleandright{leftmiddleandright}%
-\def\leftmiddleandright{\ifx\@currenvir\uulm@txt@leftmiddleandright\expandafter\uulm@leftmiddleright\else\expandafter\uulm@old@leftmiddleright\fi}
-\def\uulm@old@leftmiddleright#1#2#3{%
-	\thirdpage{#1}%
-    \hfill
-    \thirdpage{#2}%
-    \hfill
-    \thirdpage{#3}%
-}
+% corresponds to '\halfpage', however, with the new columns we could use larger values
+% (same for thirdnext)
+\def\halfnext{{.48\textwidth}}
+% corresponds to '\thirdpage'
+\def\thirdnext{{.31\textwidth}}
 
-\def\uulm@leftmiddleright{\columns[c,onlytextwidth]\def\next{\column{.31\textwidth}}\next}
-\def\endleftmiddleandright{\endcolumns}
+% now we want to create a splitter-box
+% the first argument is the name and corresponds directly to the environment/available macro
+% in this case: 'leftandright'
+% with 2 we express, that the old '\leftandright' definition required 2 arguments,
+% this enables us to refer to them with '#1' and '#2 in the next argument which basically
+% just holds the definition of the original '\leftandright'-macro
+% i removed some newlines to make it more compact (but they do not matter)
+% the last macro defines the new definition of '\next' which acts as the splitter
+\uulm@CreateSplitterBox{leftandright}{2}{\halfpage{#1}\hfill\halfpage{#2}}{\column\halfnext}
+
+\uulm@CreateSplitterBox{leftmiddleandright}{3}{\thirdpage{#1}\hfill\thirdpage{#2}\hfill\thirdpage{#3}}{\column\thirdnext}
+
 
 \newcommand{\leftthenright}[2]{
     \halfpage{#1}

--- a/beamerthemeuulm.sty
+++ b/beamerthemeuulm.sty
@@ -334,13 +334,14 @@
 % ---------------------------------------------
 % color boxes
 % ---------------------------------------------
-\renewtcolorbox{definition}[2][]{title={\setlength{\parskip}{0ex}\vphantom{/}#2},colback=orange!10,colframe=orange!30,coltitle=black,fonttitle=\bfseries,left=1mm,right=1mm,top=1mm,bottom=1mm,#1}
-
-\newcommand{\mydefinitiontight}[2]{
-	\begin{tcolorbox}[title={\setlength{\parskip}{0ex}\vphantom{/}#1},colback=white,colframe=orange!30,coltitle=black,fonttitle=\bfseries,left=0mm,right=0mm,top=0mm,bottom=0mm]
-		#2
-	\end{tcolorbox}
+\tcbset{%
+    uulm@basic-boxstyle/.style n args=4{title={\setlength{\parskip}{0ex}\vphantom{/}#2},colframe=#3!30,coltitle=black,fonttitle=\bfseries,left=#4,right=#4,top=#4,bottom=#4,#1},
+    uulm@boxstyle/.style n args=3{uulm@basic-boxstyle={#1}{#2}{#3}{1mm},colback=#3!10},
+    uulm@tightboxstyle/.style n args=3{uulm@basic-boxstyle={#1}{#2}{#3}{0mm},colback=white}
 }
+
+\renewtcolorbox{definition}[2][]{uulm@boxstyle={#1}{#2}{orange}}
+\newtcolorbox{mydefinitiontight}[2][]{uulm@tightboxstyle={#1}{#2}{orange}}
 
 \newcommand{\myexample}[2]{
 	\begin{tcolorbox}[title={\setlength{\parskip}{0ex}\vphantom{/}#1},colback=blue!10,colframe=blue!30,coltitle=black,fonttitle=\bfseries,left=1mm,right=1mm,top=1mm,bottom=1mm]

--- a/beamerthemeuulm.sty
+++ b/beamerthemeuulm.sty
@@ -340,19 +340,14 @@
     uulm@tightboxstyle/.style n args=3{uulm@basic-boxstyle={#1}{#2}{#3}{0mm},colback=white}
 }
 
-% we could group this by a generation macro
-\renewtcolorbox{definition}[2][]{uulm@boxstyle={#1}{#2}{orange}}
-\newtcbox\mydefinition[2][]{capture=minipage,uulm@boxstyle={#1}{#2}{orange}}
-\newtcolorbox{definitiontight}[2][]{uulm@tightboxstyle={#1}{#2}{orange}}
-\newtcbox\mydefinitiontight[2][]{capture=minipage,uulm@tightboxstyle={#1}{#2}{orange}}
-
-\renewtcolorbox{example}[2][]{uulm@boxstyle={#1}{#2}{blue}}
-\newtcbox\myexample[2][]{capture=minipage,uulm@boxstyle={#1}{#2}{blue}}
-\newtcolorbox{exampletight}[2][]{uulm@tightboxstyle={#1}{#2}{blue}}
-\newtcbox\myexampletight[2][]{capture=minipage,uulm@tightboxstyle={#1}{#2}{blue}}
-
-\renewtcolorbox{note}[2][]{uulm@boxstyle={#1}{#2}{red}}
-\newtcbox\mynote[2][]{capture=minipage,uulm@boxstyle={#1}{#2}{red}}
-\newtcolorbox{notetight}[2][]{uulm@tightboxstyle={#1}{#2}{red}}
-\newtcbox\mynotetight[2][]{capture=minipage,uulm@tightboxstyle={#1}{#2}{red}}
+% name | color
+\def\uulm@MakeNewBox#1#2{
+\renewtcolorbox{#1}[2][]{uulm@boxstyle={##1}{##2}{#2}}
+\expandafter\newtcbox\csname my#1\endcsname[2][]{capture=minipage,uulm@boxstyle={##1}{##2}{#2}}
+\newtcolorbox{#1tight}[2][]{uulm@tightboxstyle={##1}{##2}{#2}}
+\expandafter\newtcbox\csname my#1tight\endcsname[2][]{capture=minipage,uulm@tightboxstyle={##1}{##2}{#2}}
+}
+\uulm@MakeNewBox{definition}{orange}
+\uulm@MakeNewBox{example}{blue}
+\uulm@MakeNewBox{note}{red}
 % ---------------------------------------------

--- a/beamerthemeuulm.sty
+++ b/beamerthemeuulm.sty
@@ -248,12 +248,23 @@
 	\end{minipage}
 }
 
-
-\newcommand{\leftandright}[2]{
+% macro name [and text] | number of old args | old definition
+% | new definition (next-target only,no args => next)
+\long\def\uulm@CreateSplitterBox#1#2#3#4{%
+\@namedef{uulm@txt@#1}{#1}
+\edef\@tmp{\noexpand\@namedef{#1}{%
+\noexpand\ifx\expandonce{\csname uulm@txt@#1\endcsname}\noexpand\@currenvir\noexpand\expandafter\expandonce{\csname uulm@#1\endcsname}\noexpand\else\noexpand\expandafter\expandonce{\csname uulm@old@#1\endcsname}\noexpand\fi}}
+\@tmp
+\expandafter\newcommand\csname uulm@old@#1\endcsname[#2]{#3}
+\@namedef{uulm@#1}{\columns[c,onlytextwidth]\def\next{#4}\next}
+\@namedef{end#1}{\endcolumns}
+}
+\errorcontextlines9999
+\uulm@CreateSplitterBox{leftandright}{2}{
     \halfpage{#1}
     \hfill
     \halfpage{#2}
-}
+}{\column{.48\textwidth}}
 
 % the old version allowed to pass on three macros, we want to support this non-verbatim-safe
 % variant for legacy reasons. With '\@ifnextchar\bgroup' we could check if this macro

--- a/demo-slides/demoSlides.tex
+++ b/demo-slides/demoSlides.tex
@@ -7,6 +7,7 @@
 
 \usepackage{../beamerthemeuulm} % use the inofficial uulm beamer theme
 \setfaculty{infIngPsy} % set the color scheme for your faculty here [med/infIngPsy/math/nat]
+\usepackage{minted}
 
 \usepackage{babel}
 %\recordingtrue % special recording mode for use with a greenscreen, gives you space to show yourself in a layer in front of the slides, has no effect in the handout mode
@@ -67,28 +68,32 @@
 \end{frame}
 
 \subsection{Colored Boxes}
-\begin{frame}{\insertsubsection\ with a really really really really really really really really really really really long title\hfill With Fill!}
+\begin{frame}[fragile]{\insertsubsection\ with a really really really really really really really really really really really long title\hfill With Fill!}
 	Normal versions:
 
-	\leftmiddleandright{
-		\mydefinition{A Definition}{This is a definition.}
-	}{
+\begin{leftmiddleandright}
+		\begin{definition}{A Definition}
+			This is a definition.
+\begin{minted}{java}
+System.out.println("foo");
+\end{minted}
+		\end{definition}
+\next
 		\myexample{An Example}{This is an example.}
-	}{
+\next
 		\mynote{A Note}{This is a note.}
-	}
-
+\end{leftmiddleandright}
 	\vfill
 
 	Tight versions (e.g., for use with pictures):
 
-	\leftmiddleandright{
+\begin{leftmiddleandright}
 		\mydefinitiontight{A Definition}{This is a definition.}
-	}{
+\next
 		\myexampletight{An Example}{This is an example.}
-	}{
+\next
 		\mynotetight{A Note}{This is a note.}
-	}
+\end{leftmiddleandright}
 \end{frame}
 
 \section{Slide Layouts}
@@ -108,13 +113,13 @@
 
 \subsection{Left, Middle, and Right}
 \begin{frame}{\insertsubsection}
-    \leftmiddleandright{
+\begin{leftmiddleandright}
         This is an example text that is shown in the \textbf{left column}.
-    }{
+\next
         This is an example text that is shown in the \textbf{middle column}.
-    }{
+\next
         This is an example text that is shown in the \textbf{right column}.
-    }
+\end{leftmiddleandright}
 	\vfill
 	\mynote{Explanation}{
 		All columns are visible in \textbf{handout}, \textbf{slide}, and \textbf{recording} mode (i.e., there are no animations).

--- a/demo-slides/demoSlides.tex
+++ b/demo-slides/demoSlides.tex
@@ -89,19 +89,19 @@ System.out.println("foo");
 
 	Tight versions (e.g., for use with pictures):
 
-\begin{leftmiddleandright}
+\leftmiddleandright{%
 		\begin{definitiontight}{A Definition}
 			This is a definition.
 		\end{definitiontight}
-\next
+}{%
 		\begin{exampletight}{An Example}
 			This is an example.
 		\end{exampletight}
-\next
+}{%
 		\begin{notetight}{A Note}
 			This is a note.
 		\end{notetight}
-\end{leftmiddleandright}
+}
 \end{frame}
 
 \section{Slide Layouts}

--- a/demo-slides/demoSlides.tex
+++ b/demo-slides/demoSlides.tex
@@ -88,7 +88,9 @@ System.out.println("foo");
 	Tight versions (e.g., for use with pictures):
 
 \begin{leftmiddleandright}
-		\mydefinitiontight{A Definition}{This is a definition.}
+		\begin{mydefinitiontight}{A Definition}
+			This is a definition.
+		\end{mydefinitiontight}
 \next
 		\myexampletight{An Example}{This is an example.}
 \next

--- a/demo-slides/demoSlides.tex
+++ b/demo-slides/demoSlides.tex
@@ -10,7 +10,7 @@
 \usepackage{minted}
 
 \usepackage{babel}
-%\recordingtrue % special recording mode for use with a greenscreen, gives you space to show yourself in a layer in front of the slides, has no effect in the handout mode
+% \recordingtrue % special recording mode for use with a greenscreen, gives you space to show yourself in a layer in front of the slides, has no effect in the handout mode
 
 \title[Short Title]{This is the Long Title} % short title is used for the slide footer but optional
 \ThemeLetter{A}
@@ -78,9 +78,9 @@
 System.out.println("foo");
 \end{minted}
 		\end{definition}
-\next
+\second
 		\myexample{An Example}{This is an example.}
-\next
+\third
 		\begin{note}{A Note}
 			This is a note.
 		\end{note}
@@ -123,9 +123,9 @@ System.out.println("foo");
 \begin{frame}{\insertsubsection}
 \begin{leftmiddleandright}
         This is an example text that is shown in the \textbf{left column}.
-\next
+\second
         This is an example text that is shown in the \textbf{middle column}.
-\next
+\third
         This is an example text that is shown in the \textbf{right column}.
 \end{leftmiddleandright}
 	\vfill
@@ -155,7 +155,7 @@ System.out.println("foo");
 	 \vfill
 	 \begin{leftthenright}
 		This is an example text that is shown in the \textbf{left column}.
-		\next\show\next
+	\second
 		This is an example text that is shown in the \textbf{right column}.
 	 \end{leftthenright}
 	\vfill

--- a/demo-slides/demoSlides.tex
+++ b/demo-slides/demoSlides.tex
@@ -116,7 +116,7 @@ System.out.println("foo");
         This is an example text that is shown in the \textbf{right column}.
     }
 	\vfill
-	\begin{note}s{Explanation}
+	\begin{note}{Explanation}
 		Both columns are visible in \textbf{handout}, \textbf{slide}, and \textbf{recording} mode (i.e., there are no animations).
 	\end{note}
 \end{frame}

--- a/demo-slides/demoSlides.tex
+++ b/demo-slides/demoSlides.tex
@@ -79,9 +79,7 @@ System.out.println("foo");
 \end{minted}
 		\end{definition}
 \next
-		\begin{example}{An Example}
-			This is an example.
-		\end{example}
+		\myexample{An Example}{This is an example.}
 \next
 		\begin{note}{A Note}
 			This is a note.

--- a/demo-slides/demoSlides.tex
+++ b/demo-slides/demoSlides.tex
@@ -152,6 +152,12 @@ System.out.println("foo");
     }{
         This is an example text that is shown in the \textbf{right column}.
     }
+	 \vfill
+	 \begin{leftthenright}
+		This is an example text that is shown in the \textbf{left column}.
+		\next\show\next
+		This is an example text that is shown in the \textbf{right column}.
+	 \end{leftthenright}
 	\vfill
 	\mynote{Explanation}{
 		In \textbf{handout} mode, both columns are visible.

--- a/demo-slides/demoSlides.tex
+++ b/demo-slides/demoSlides.tex
@@ -146,7 +146,7 @@ System.out.println("foo");
 \section{Animated Slide Layouts}
 
 \subsection{Left then Right}
-\begin{frame}{\insertsubsection}
+\begin{frame}[fragile]{\insertsubsection}
     \leftthenright{
         This is an example text that is shown in the \textbf{left column}.
     }{
@@ -155,8 +155,14 @@ System.out.println("foo");
 	 \vfill
 	 \begin{leftthenright}
 		This is an example text that is shown in the \textbf{left column}.
+	\begin{minted}{java}
+class Example {}
+	\end{minted}
 	\second
 		This is an example text that is shown in the \textbf{right column}.
+	\begin{minted}{java}
+class ExampleB extends Example {}
+	\end{minted}
 	 \end{leftthenright}
 	\vfill
 	\mynote{Explanation}{

--- a/demo-slides/demoSlides.tex
+++ b/demo-slides/demoSlides.tex
@@ -79,22 +79,30 @@ System.out.println("foo");
 \end{minted}
 		\end{definition}
 \next
-		\myexample{An Example}{This is an example.}
+		\begin{example}{An Example}
+			This is an example.
+		\end{example}
 \next
-		\mynote{A Note}{This is a note.}
+		\begin{note}{A Note}
+			This is a note.
+		\end{note}
 \end{leftmiddleandright}
 	\vfill
 
 	Tight versions (e.g., for use with pictures):
 
 \begin{leftmiddleandright}
-		\begin{mydefinitiontight}{A Definition}
+		\begin{definitiontight}{A Definition}
 			This is a definition.
-		\end{mydefinitiontight}
+		\end{definitiontight}
 \next
-		\myexampletight{An Example}{This is an example.}
+		\begin{exampletight}{An Example}
+			This is an example.
+		\end{exampletight}
 \next
-		\mynotetight{A Note}{This is a note.}
+		\begin{notetight}{A Note}
+			This is a note.
+		\end{notetight}
 \end{leftmiddleandright}
 \end{frame}
 
@@ -108,9 +116,9 @@ System.out.println("foo");
         This is an example text that is shown in the \textbf{right column}.
     }
 	\vfill
-	\mynote{Explanation}{
+	\begin{note}s{Explanation}
 		Both columns are visible in \textbf{handout}, \textbf{slide}, and \textbf{recording} mode (i.e., there are no animations).
-	}
+	\end{note}
 \end{frame}
 
 \subsection{Left, Middle, and Right}


### PR DESCRIPTION
This closes #6 and adds several features while staying completely backwards compatible (except for special tex-hacky cases because we rely on different internal definitions):

* For the old macros `\mydefinition`, `\mydefinitiontight` etc. there are now environments
  `definition` and `definitiontight` which are completely verbatim-safe (i added an example to
  the demo-slides).
* All splits (e.g.,  `leftmiddleandright`) can be used either as macro (just like before) or as
  a verbatim-safe variant.\
  The mechanism used to check this is not completely safe, but the technique is widespread
  and e.g. used by beamer itself and several other packages. Some tex-hackery is
  needed to break it.

Furthermore, I have documented the procedure.